### PR TITLE
DataFinder: Update available groups after saving

### DIFF
--- a/DataFinder/src/client/DataFinder/components/Banner.tsx
+++ b/DataFinder/src/client/DataFinder/components/Banner.tsx
@@ -121,7 +121,9 @@ export const ManageGroupsDropdownFC : React.FC<ManageGroupDropdownProps> = (({
         {
             label: "Save",
             action: () => {
-                ParticipantGroupHelpers.saveParticipantGroup(groupSummary); 
+                ParticipantGroupHelpers.saveParticipantGroup(groupSummary).then(() => {
+                    updateAvailableGroups()
+                })
                 setGroupSummary((prevGroupSummary) => prevGroupSummary.with({isSaved: true})) },
             disabled: !(groupSummary.id > 0)
         },

--- a/DataFinder/src/client/DataFinder/components/reusable/Dropdowns.scss
+++ b/DataFinder/src/client/DataFinder/components/reusable/Dropdowns.scss
@@ -78,7 +78,7 @@
       &:hover {
         color: #f7f7f7;
         text-decoration: none;
-        background-color: #597530;  
+        background-color: #3495d2; // This is the color on prod. It will look weird on test/local where colors are different
       }
 
     }

--- a/DataFinder/src/client/DataFinder/helpers/ParticipantGroup.tsx
+++ b/DataFinder/src/client/DataFinder/helpers/ParticipantGroup.tsx
@@ -276,7 +276,7 @@ export const sendParticipantGroup = (groupSummary, saveAsCallback) => {
 
 export const saveParticipantGroup = (groupSummary) => {
     if (groupSummary.id > 0) {
-        getSessionParticipantGroup().then((data) => {
+        return getSessionParticipantGroup().then((data) => {
                 const description = JSON.parse(data.description)
                 description.summary.isSaved = true
                 data.label = description.summary.label           


### PR DESCRIPTION
Fixes a bug where the load groups dropdown does not update when a group is saved. 